### PR TITLE
Remove lttng stop

### DIFF
--- a/labs/01-tracing-wget-critical-path/01-tracing-wget-critical-path.md
+++ b/labs/01-tracing-wget-critical-path/01-tracing-wget-critical-path.md
@@ -22,7 +22,6 @@ $ lttng create
 $ lttng enable-event -k -a
 $ lttng start
 $ wget http://www.dorsal.polymtl.ca
-$ lttng stop
 $ lttng destroy
 ```
 


### PR DESCRIPTION
lttng stop is performed on lttng destroy implicitly since lttng 2.8.
-----
commit e20ee7c273030ac52eea4778f03dc3a9d65857b3
Author: Julien Desfossez <jdesfossez@efficios.com>
Date:   Fri Jul 3 17:08:27 2015 -0400

    Explicitly stop the session on lttng destroy
    
    This changes the default behavior of the "destroy" command and API: now
    it implicitely stops the tracing and waits for the data to be available
    on disk or the network. Like the "stop" command and API, a no_wait
    option is available to skip the waiting and destroy directly the
    session.
    
    Signed-off-by: Julien Desfossez <jdesfossez@efficios.com>
    Signed-off-by: Jérémie Galarneau <jeremie.galarneau@efficios.com>
------

Given that the instruction make it clear to use the ppa (2.10 at this time) this should not result in any problem.